### PR TITLE
[Misc] Add .github/commit_message_template

### DIFF
--- a/.github/commit_message_template
+++ b/.github/commit_message_template
@@ -1,0 +1,35 @@
+[<tag>] <One-line description of the patch>
+#
+# <tag> can be:
+#   GC        Dragonwell specific JVM GC changes
+#   Runtime   Dragonwell specific JVM runtime changes
+#   JIT       Dragonwell Just-in-Time compiler changes
+#   JFR       JFR related
+#   JWarmUp   JWarmUp related
+#   Misc      Miscellaneous changes, such as Makefile, scripts
+#
+
+Summary: <detailed description of the change>
+#
+# Detailed description of the changes
+#   Problems fixed by this change
+#   New features added by this change
+#
+
+Test Plan: <how this patch has been tested>
+#
+# Please explain
+#   - Approaches used
+#   - Testsuites selected.
+#
+
+Reviewed-by: <Github IDs of reviewers>
+#
+# For code changes, at least two reviewers required
+#
+
+Issue: <full URL or #github_tag>
+#
+# Link of the fixed issue, can be full URL or github bug id (e.g. #123)
+#
+


### PR DESCRIPTION
Summary:
- Added .github/commit_message_template file
- Developers are expected to use following command to create any new Git commits
`git commit -t .github/commit_message_template`

Test Plan: only review needed

Reviewed-by: kuaiwei, sanhong

Issue: #18